### PR TITLE
Continuous Integration

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,3 @@
+---
+BasedOnStyle: Mozilla
+BreakBeforeBraces: Attach

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ dist: precise
 addons:
   apt:
     packages:
-    - build-essentials
+    - build-essential
+    - clang-format-3.4
     - linux-libc-dev
     - libpam0g-dev
 
 git:
   depth: 3
 
-script: make
+script: ./test.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+sudo: false
+dist: precise
+
+addons:
+  apt:
+    packages:
+    - build-essentials
+    - linux-libc-dev
+    - libpam0g-dev
+
+git:
+  depth: 3
+
+script: make

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,20 @@
 sudo: false
 dist: precise
 
+env:
+  global:
+  # encrypted COVERITY_SCAN_TOKEN
+  - secure: "jAKcq+1cALbQthqYxaQaeDEp9GY6FSmIvDLSZ+eQJoA8Qx5AHftCaaBiLsmQx7MQeNgPNL5d64NXjFIT6skhngUHhMS1qXlVzUAF0gqdjKOqhbBYjHBoGEeCdwIhQIrJxQ/lvbMpXF+G+uurp3QNU70p+B6xO8cMvCy2uKLdn5vq4wZL4VEZJ4aENJ1Js1YSC3/81tm1dSIGIrdJ4Hrd9GxMXhMTCdbjOFFfGLOoo2jYQAmiOvNwi29YohwTs2ylg2hNjae7dwKMiLbm5xYXC9QIGFMgGSw87PIiPwMJDOznPyDQfmBfwvOdqMzC7QU6/JC6zmlAemyTi1n8jVzjOCgU89MJg6PG50gCznEb5q1rySsImAruv7tFrx9TTpOwbimPdUtddLQE8XSA3o89/g/lLGGBKJlAKDEcw7LR4V489jmisyB7ZTX5ASAy8xzfvrYKAjSbEKOpiNOXs3/03vXHP5FjpMVJ5KapEU23MmMiVjx+IrxVLVtA4C7Pblre7mrre31TrRb7EErqt+hraSuVdT1PRWWaBLJRs5mt+0RBz55eZmcg1J5j5lJoQQReixPy4kQ7yO1nxEmCS+QSYAvi9pprO43FA+mOy8b6ZSsgdxzv8vNQ9Ju5Is9KTiSO9VbZUdi8CCtylaLkkwzZuRNHGkcTtST4TryfYAuR9ck="
+
 addons:
+  coverity_scan:
+    project:
+      name: "hashbang/pam_setquota"
+      description: "PAM module for setting disk quotas on login"
+    notification_email: kellerfuchs@hashbang.sh
+    build_command: "make"
+    branch_pattern: coverity_scan
+
   apt:
     packages:
     - build-essential

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ev
+
+make
+clang-format-3.4 pam_setquota.c | diff -q pam_setquota.c -


### PR DESCRIPTION
This PR adds the continuous integration I used while working on a [fork](https://github.com/hashbang/pam_setquota) at [#!](https://hashbang.sh).
- It provides Travis CI-based builds that
  - check the code builds
  - and check the indentation/formatting is correct.
- It uses the Coverity Scan linter to look for issues.

Should you merge this, you will want to enable Travis CI for your repo (no account creation needed, they use OAuth to tie to your Github account) and obtain a new token from Coverity.
